### PR TITLE
Fix narray link errors on Windows rubyinstaller2.

### DIFF
--- a/ext/numo/fftw/extconf.rb
+++ b/ext/numo/fftw/extconf.rb
@@ -22,6 +22,21 @@ EOL
   exit(1)
 end
 
+if /cygwin|mingw/ =~ RUBY_PLATFORM
+  narray_include = File.expand_path(File.dirname(Gem.find_files("numo/numo/narray.h")[0]))
+  narray_lib = File.expand_path(File.dirname(Gem.find_files("numo/libnarray.a")[0]))
+  dir_config('narray', narray_include, narray_lib)
+
+  if !have_library('narray')
+    print <<EOL
+    Library libnarray.a was not found. Give pathname as follows:
+    % ruby extconf.rb --with-narray-lib=library_dir
+EOL
+    exit(-1)
+  end
+
+end
+
 if !have_header('fftw3.h')
   print <<EOL
   Header fftw3.h was not found. Give pathname as follows:


### PR DESCRIPTION
This patch resolves issue #1.

I think numo-fftw failed to link to the narray library on windows rubyinstaller2.




My fftw version  on windows cmd. 
The [ridk](https://github.com/oneclick/rubyinstaller2/wiki/The-ridk-tool) command is a helper tool of rubyinstaller2.
```
C:\Users\icm7216\numo_fftw_test\numo-fftw>ridk exec pacman -Ss fftw
mingw32/mingw-w64-i686-fftw 3.3.8-2
    A library for computing the discrete Fourier transform (DFT) (mingw-w64)
mingw64/mingw-w64-x86_64-fftw 3.3.8-2 [インストール済み]
    A library for computing the discrete Fourier transform (DFT) (mingw-w64)
```

My ruby version
```
C:\Users\icm7216\numo_fftw_test\numo-fftw>ruby --version
ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x64-mingw32]
```

build
```
C:\Users\icm7216\numo_fftw_test\numo-fftw>gem build numo-fftw.gemspec
WARNING:  license value 'GPL2' is invalid.  Use a license identifier from
http://spdx.org/licenses or 'Nonstandard' for a nonstandard license.
Did you mean 'NGPL'?
WARNING:  open-ended dependency on numo-narray (>= 0.9.0.8) is not recommended
  if numo-narray is semantically versioned, use:
    add_runtime_dependency 'numo-narray', '~> 0.9', '>= 0.9.0.8'
WARNING:  See https://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: numo-fftw
  Version: 0.1.1
  File: numo-fftw-0.1.1.gem
```

install
```
C:\Users\icm7216\numo_fftw_test\numo-fftw>gem install numo-fftw-0.1.1.gem
Temporarily enhancing PATH for MSYS/MINGW...
Building native extensions. This could take a while...
Successfully installed numo-fftw-0.1.1
Parsing documentation for numo-fftw-0.1.1
Installing ri documentation for numo-fftw-0.1.1
Done installing documentation for numo-fftw after 0 seconds
1 gem installed
```
There were no errors during installation with this patch.

test
```
C:\Users\icm7216\numo_fftw_test\numo-fftw>irb -r "numo/narray" -r "numo/fftw"
irb(main):001:0> na = Numo::DComplex.new(4)
=> Numo::DComplex#shape=[4](empty)
irb(main):002:0> na = [0.0+0.0i, 1.0+0.0i, 0.0+0.0i, 0.0+0.0i]
=> [(0.0+0.0i), (1.0+0.0i), (0.0+0.0i), (0.0+0.0i)]
irb(main):003:0> b = Numo::FFTW.dft(na, -1)
=>
Numo::DComplex#shape=[4]
...
irb(main):004:0> b
=>
Numo::DComplex#shape=[4]
[1+0i, 0-1i, -1+0i, 0+1i]
```
